### PR TITLE
enable INSERT stmt w/out naming fields; simpler check for field/value count

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -66,8 +66,8 @@
 -record(riak_sql_insert_v1,
         {
           'INSERT'      = <<>>  :: binary(),
-          fields                :: [identifier()],
-          values                :: [[value_type()]],
+          fields                :: [field_identifier()],
+          values                :: [[riak_ql_ddl:data_value()]],
           helper_mod            :: atom()
         }).
 


### PR DESCRIPTION
* expect either zero or a matching number of fields in `#riak_sql_insert_v1.fields`; if 0, fetch the DDL, extract fields, and reenter `make_insert_response/2` (seems not necessary, see `riak_kv_ts_util:build_sql_record/3`).
* `lookup_field_positions` is guaranteed to be the same size as length of fields it was called with, so remove checks in `xlate_insert_to_putdata/3` for those lengths being unequal.
* slim down `make_insert_row`, eventually "fixing" one particularly dense dialyzer issue.